### PR TITLE
Add environment example file and document secret handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# Copy this file to .env.local (which is git-ignored) and fill in values
+# with your own credentials. Never commit real secrets to the repository.
+
+# Required database connection string for Drizzle and Neon.
+DATABASE_URL="postgresql://USER:PASSWORD@HOST:PORT/DATABASE?sslmode=require"
+
+# Add any other API keys or tokens your deployment requires as needed.
+# For example:
+# VERCEL_AI_GATEWAY_URL="https://gateway.ai.vercel.com/api/v1"
+# VERCEL_AI_GATEWAY_TOKEN="your-token"

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Paste any facts or docs into the chat and this app will chunk them, generate emb
 1. Clone the repository you created above: `git clone <repo-url>`
 1. Link it to a Vercel project: `vc link` or `vc deploy`
 1. Pull environment variables with `vc env pull`
+   - If you prefer managing secrets manually, copy `.env.example` to `.env.local` and fill in your own values. This file is git-ignored so you can keep credentials out of version control.
 1. Install packages with `pnpm i` (or `npm i` or `yarn i`)
 1. Run a database migration with `pnpm db:migrate && pnpm db:push`
 1. Run the development server with `vc dev` and open http://localhost:3000 to try the chatbot


### PR DESCRIPTION
## Summary
- add a `.env.example` template with placeholder values and guidance to keep secrets out of git
- document the manual environment variable setup option in the README setup instructions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1dbba479c83298e7bc304105a572d